### PR TITLE
Add view state

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -32,7 +32,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book!";
-    public static final String MESSAGE_NOT_IN_LIST_MODE = "You need to be in list mode to add a person.";
+    public static final String MESSAGE_NOT_LIST_MODE = "You need to be in list mode to add a person.";
 
     private final Person toAdd;
 
@@ -48,7 +48,7 @@ public class AddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (model.isFullView()) {
-            throw new CommandException(MESSAGE_NOT_IN_LIST_MODE);
+            throw new CommandException(MESSAGE_NOT_LIST_MODE);
         }
 
         if (model.hasPerson(toAdd)) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -27,11 +27,12 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_LESSON_PLAN + "Data structures "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "Science "
+            + PREFIX_TAG + "Maths";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book!";
+    public static final String MESSAGE_NOT_IN_LIST_MODE = "You need to be in list mode to add a person.";
 
     private final Person toAdd;
 
@@ -46,6 +47,9 @@ public class AddCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (model.isFullView()) {
+            throw new CommandException(MESSAGE_NOT_IN_LIST_MODE);
+        }
 
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,8 +42,6 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
-        model.setListView();
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -42,6 +43,7 @@ public class DeleteCommand extends Command {
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
         model.setListView();
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -41,6 +41,7 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        model.setListView();
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -61,6 +61,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_NOT_VIEW_MODE = "You need to be in full view mode to edit a person.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;
@@ -80,6 +81,10 @@ public class EditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        if (!model.isFullView()) {
+            throw new CommandException(MESSAGE_NOT_VIEW_MODE);
+        }
+
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -14,10 +14,10 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
-
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        model.setListView();
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCommand.java
@@ -29,11 +29,12 @@ public class ViewCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        model.setFullView();
+
         Person person = model.getFilteredPersonList().get(0);
         person.setFullView();
-        return new CommandResult(
-                String.format(Messages.MESSAGE_PERSON_FULL_VIEW,
-                        person.getName().fullName), false, false);
+
+        return new CommandResult(String.format(Messages.MESSAGE_PERSON_FULL_VIEW, person.getName().fullName));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -93,6 +93,13 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     * Sets all {@code persons} to be in list view mode.
+     */
+    public void setAllToListView() {
+        persons.setAllToListView();
+    }
+
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -76,6 +76,21 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
+    /**
+     * Toggles the full view to view mode where details of a single person are listed in full.
+     */
+    void setFullView();
+
+    /**
+     * Toggles the full view to list mode where details are truncated.
+     */
+    void setListView();
+
+    /**
+     * Returns true if the address book is currently in full view mode.
+     */
+    boolean isFullView();
+
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,6 +23,8 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    private boolean fullView;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        fullView = false;
     }
 
     public ModelManager() {
@@ -109,6 +112,22 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    @Override
+    public void setFullView() {
+        fullView = true;
+    }
+
+    @Override
+    public void setListView() {
+        fullView = false;
+        addressBook.setAllToListView();
+    }
+
+    @Override
+    public boolean isFullView() {
+        return fullView;
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -67,6 +67,7 @@ public class Person {
     public AttendanceList getAttendanceList() {
         return attendanceList;
     }
+
     public SessionList getSessionList() {
         return sessionList;
     }
@@ -80,24 +81,24 @@ public class Person {
     }
 
     /**
-     * Toggle fullView to true to allow for toString to be
-     * called when setting PersonListCard.
-     * This is called when ViewCommand is the command input by user.
+     * Sets the person's details to be listed in full.
      */
     public void setFullView() {
         fullView = true;
     }
 
     /**
-     * checks fullView, then sets fullView to false if fullView is true.
-     * @return a boolean to signify whether the Person object should be displayed in fullView.
+     * Sets the person's details to be truncated in list mode.
+     */
+    public void setListView() {
+        fullView = false;
+    }
+
+    /**
+     * Returns whether the person's details are fully listed.
      */
     public boolean isFullView() {
-        if (fullView) {
-            fullView = false;
-            return true;
-        }
-        return false;
+        return fullView;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -98,6 +98,13 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Sets all {@code persons} in this list to be in list view mode.
+     */
+    public void setAllToListView() {
+        internalList.forEach(Person::setListView);
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -51,6 +51,15 @@ public class AddCommandTest {
     }
 
     @Test
+    public void execute_notListMode_throwsCommandException() {
+        Person validPerson = new PersonBuilder().build();
+        AddCommand addCommand = new AddCommand(validPerson);
+        ModelStub modelStub = new ModelStubInFullView();
+
+        assertThrows(CommandException.class, AddCommand.MESSAGE_NOT_LIST_MODE, () -> addCommand.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         Person alice = new PersonBuilder().withName("Alice").build();
         Person bob = new PersonBuilder().withName("Bob").build();
@@ -75,7 +84,7 @@ public class AddCommandTest {
     }
 
     /**
-     * A default model stub that have all of the methods failing.
+     * A default model stub that has all methods failing.
      */
     private class ModelStub implements Model {
         @Override
@@ -150,7 +159,7 @@ public class AddCommandTest {
 
         @Override
         public boolean isFullView() {
-            return false;
+            throw new AssertionError("This method should not be called.");
         }
 
         @Override
@@ -180,6 +189,11 @@ public class AddCommandTest {
             requireNonNull(person);
             return this.person.isSamePerson(person);
         }
+
+        @Override
+        public boolean isFullView() {
+            return false;
+        }
     }
 
     /**
@@ -203,6 +217,21 @@ public class AddCommandTest {
         @Override
         public ReadOnlyAddressBook getAddressBook() {
             return new AddressBook();
+        }
+
+        @Override
+        public boolean isFullView() {
+            return false;
+        }
+    }
+
+    /**
+     * A Model stub that is always in full view mode.
+     */
+    private class ModelStubInFullView extends ModelStub {
+        @Override
+        public boolean isFullView() {
+            return true;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -139,6 +139,21 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setFullView() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setListView() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean isFullView() {
+            return false;
+        }
+
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -169,6 +169,13 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_notInViewMode_failure() {
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
+
+        assertCommandFailure(editCommand, model, EditCommand.MESSAGE_NOT_VIEW_MODE);
+    }
+
+    @Test
     public void equals() {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -41,8 +41,13 @@ public class EditCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
+    public void setFullView() {
+        model.setFullView();
+    }
+
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        setFullView();
         Person editedPerson = new PersonBuilder().withHomework(VALID_HOMEWORK_BOB)
                 .withAttendance(VALID_ATTENDANCE_BOB).withGradeProgress(VALID_GRADE_PROGRESS_BOB)
                 .withSession(VALID_SESSION_BOB).build();
@@ -61,6 +66,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        setFullView();
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
 
@@ -82,6 +88,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
+        setFullView();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
@@ -94,6 +101,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_filteredList_success() {
+        setFullView();
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -111,6 +119,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
+        setFullView();
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(firstPerson).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
@@ -120,6 +129,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
+        setFullView();
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         // edit person in filtered list into a duplicate in address book
@@ -132,6 +142,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_invalidPersonIndexUnfilteredList_failure() {
+        setFullView();
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
@@ -145,6 +156,7 @@ public class EditCommandTest {
      */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
+        setFullView();
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
         // ensures that outOfBoundIndex is still in bounds of address book list


### PR DESCRIPTION
`view` and `list` specifically toggle the app between the two viewing modes.

Works in view only:

- `edit`
- `remove` (not implemented yet)

Works in list only:
- `add`

Commands not mentioned work in both. Running `delete` in view mode will set it back to list mode (since you will be deleting the only person in view, no one will be shown afterwards and you would have to return to list anyway).